### PR TITLE
overloaded the CalcDistance Function to allo

### DIFF
--- a/IceBlinkCore/IceBlinkCore/Convo.cs
+++ b/IceBlinkCore/IceBlinkCore/Convo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections;
 using System.Text;
@@ -145,6 +145,10 @@ namespace IceBlinkCore
         public void SaveContentConversation(string fileName)
         {
             StreamWriter writer = null;
+            if (fileName.Substring(fileName.Length-4,4) != ".xml") //JamesManhattan 11/17/14 added this just to be sure to save conversations correctly, it worked!!
+            {
+                fileName = fileName + ".xml";
+            }
             try
             {
                 XmlSerializer ser = new XmlSerializer(typeof(Convo));

--- a/IceBlinkScriptFunctions/IceBlinkScriptFunctions/ScriptFunctions.cs
+++ b/IceBlinkScriptFunctions/IceBlinkScriptFunctions/ScriptFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
@@ -641,7 +641,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "Couldn't find the tag specified...returning a value of -1");
+                frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
             }
             return -1;
         }
@@ -662,7 +662,7 @@ namespace IceBlink
                     }
                     // * sinopip, 16.08.14
                     if (frm.debugMode)
-                    IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
                     return -1;
                 }
             }
@@ -681,7 +681,7 @@ namespace IceBlink
                     }
                     // * sinopip, 16.08.14
                     if (frm.debugMode)
-                    IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
                     return -1;
                 }
                 #endregion
@@ -699,7 +699,7 @@ namespace IceBlink
                         }
                         // * sinopip, 16.08.14
                     	if (frm.debugMode)
-                    	IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -718,7 +718,7 @@ namespace IceBlink
                         }
                         // * sinopip, 16.08.14
                    		if (frm.debugMode)
-                    	IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -740,7 +740,7 @@ namespace IceBlink
                         }
                         // * sinopip, 16.08.14
                     	if (frm.debugMode)
-                    	IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -759,7 +759,7 @@ namespace IceBlink
                         }
                         // * sinopip, 16.08.14
                     	if (frm.debugMode)
-                    	IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -767,7 +767,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props), returning a value of -1");
+                frm.logText("couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props), returning a value of -1", Color.Yellow);
             }
             return -1;
         }
@@ -958,7 +958,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)");
+                frm.logText("couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)", Color.Yellow);
             }
         }
         public bool CheckGlobalInt(string variableName, string compare, int value)
@@ -1295,7 +1295,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)");
+                frm.logText("couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)", Color.Yellow);
             }
             return false;
         }
@@ -1311,7 +1311,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "Couldn't find the tag specified...returning a value of -1");
+                frm.logText("Couldn't find the tag specified...returning a value of -1", Color.Yellow);
             }
             return -1;
         }
@@ -1330,7 +1330,7 @@ namespace IceBlink
                             return variable.Object;
                         }
                     }
-                    IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                    frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                     return -1;
                 }
             }
@@ -1347,7 +1347,7 @@ namespace IceBlink
                             return variable.Object;
                         }
                     }
-                    IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                    frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                     return -1;
                 }
                 #endregion
@@ -1363,7 +1363,7 @@ namespace IceBlink
                                 return variable.Object;
                             }
                         }
-                        IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -1380,7 +1380,7 @@ namespace IceBlink
                                 return variable.Object;
                             }
                         }
-                        IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -1400,7 +1400,7 @@ namespace IceBlink
                                 return variable.Object;
                             }
                         }
-                        IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -1417,7 +1417,7 @@ namespace IceBlink
                                 return variable.Object;
                             }
                         }
-                        IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return -1;
                     }
                 }
@@ -1425,7 +1425,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props), returning a value of -1");
+                frm.logText("couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props), returning a value of -1", Color.Yellow);
             }
             return -1;
         }
@@ -1606,7 +1606,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props)");
+                frm.logText("couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props)", Color.Yellow);
             }
         }
         #endregion
@@ -1708,12 +1708,18 @@ namespace IceBlink
                         CreatureUsesTrait(crt);
                     }
                 }
+                else if ((ChosenAction)ActionToTake == ChosenAction.DoNothing) //JamesManhattan 10/9/14 added option to do nothing, especially useful if you hijack the crtOnStartCombatTurn to be an entire A.I.
+                {                    
+                    //IBMessageBox.Show(gm, "does nothing!: " );
+                    //frm.currentCombat.logText(crt.Name + " does nothing...", Color.DarkRed);
+      
+                }
                 ActionToTake = null;
                 SpellToCast = null;
                 TraitToUse = null;
 
                 #region onEndCombatTurn
-                // run OnStartCombatTurn script
+                // run onEndCombatTurn script
                 var scriptEndCrt = crt.OnEndCombatTurn;
                 frm.doScriptBasedOnFilename(scriptEndCrt.FilenameOrTag, scriptCrt.Parm1, scriptCrt.Parm2, scriptCrt.Parm3, scriptCrt.Parm4);
                 #endregion
@@ -1742,14 +1748,14 @@ namespace IceBlink
                 if (crt_pt.HP > 0)
                 {
                     #region OnAttack
-                    // run OnStartCombatTurn script 
+                    // run OnAttack script 
                     CombatTarget = char_pt;
                     CombatSource = crt_pt;
                     var scriptCrt = crt_pt.OnAttack;
                     frm.doScriptBasedOnFilename(scriptCrt.FilenameOrTag, scriptCrt.Parm1, scriptCrt.Parm2, scriptCrt.Parm3, scriptCrt.Parm4);
                     #endregion
                     #region CreatureAttack
-                    // run OnStartCombatTurn script 
+                    // run dsAttackCreature script 
                     CombatTarget = char_pt;
                     CombatSource = crt_pt;
                     frm.doScriptBasedOnFilename("dsAttackCreature.cs", "none", "none", "none", "none");
@@ -1783,14 +1789,14 @@ namespace IceBlink
                     if (crt_pt.HP > 0)
                     {
                         #region OnAttack
-                        // run OnStartCombatTurn script 
+                        // run OnAttack script 
                         CombatTarget = char_pt;
                         CombatSource = crt_pt;
                         var scriptCrt = crt_pt.OnAttack;
                         frm.doScriptBasedOnFilename(scriptCrt.FilenameOrTag, scriptCrt.Parm1, scriptCrt.Parm2, scriptCrt.Parm3, scriptCrt.Parm4);
                         #endregion
                         #region CreatureAttack
-                        // run OnStartCombatTurn script 
+                        // run dsAttackCreature script 
                         CombatTarget = char_pt;
                         CombatSource = crt_pt;
                         frm.doScriptBasedOnFilename("dsAttackCreature.cs", "none", "none", "none", "none");
@@ -1806,6 +1812,38 @@ namespace IceBlink
                     #endregion
                 }
             }
+        }
+        public void CreatureMoves(Creature crt_pt, PC char_pt)
+        {
+
+            char_pt = (PC)CombatTarget;
+            // determine if ranged or melee
+            
+            
+                setupPathfindArray(crt_pt, char_pt);
+                pathfinder.Squares[crt_pt.CombatLocation.X, crt_pt.CombatLocation.Y].ContentCode = SquareContent.Monster;
+                pathfinder.Squares[char_pt.CombatLocation.X, char_pt.CombatLocation.Y].ContentCode = SquareContent.Hero;
+                Recalculate(crt_pt);
+                setupHeroSquares(char_pt, crt_pt);
+                navigatePath(crt_pt);
+                frm.currentCombat.logText(crt_pt.Name + " Moving towards ", Color.LightGray);                
+            
+        }
+        public void CreatureMoves(Creature crt_pt, Creature crt_tgt) //JamesManhattan 10/9/14 needed a function to cause creature to move next to another creature!
+        {
+
+            crt_tgt = (Creature)CombatTarget;
+            // determine if ranged or melee
+
+
+            setupPathfindArray(crt_pt, crt_tgt);
+            pathfinder.Squares[crt_pt.CombatLocation.X, crt_pt.CombatLocation.Y].ContentCode = SquareContent.Monster;
+            pathfinder.Squares[crt_tgt.CombatLocation.X, crt_tgt.CombatLocation.Y].ContentCode = SquareContent.Hero; //JamesManhattan 10/9/14 needs to be Hero even though its not 
+            Recalculate(crt_pt);
+            setupMonsterSquares(crt_tgt, crt_pt);
+            navigatePath(crt_pt);
+            frm.currentCombat.logText(crt_pt.Name + " Moving towards ", Color.LightGray);
+
         }
         public void CreatureCastsSpell(Creature crt)
         {
@@ -2339,7 +2377,7 @@ namespace IceBlink
                 if ((crt.HP > 0) && (crt.Status != CharBase.charStatus.Held) && (crt.Status != CharBase.charStatus.Sleeping)) //SD_20131215
                 {
                     //if started in distance = 1 and now distance = 2 then do attackOfOpportunity
-                    if ((CalcDistance(crt.CombatLocation, lastPlayerLocation) == 1) && (CalcDistance(crt.CombatLocation, pc.CombatLocation) == 2))
+                    if ((CalcDistance(crt, lastPlayerLocation) == 1) && (CalcDistance(crt, pc) == 2))
                     {
                         frm.currentCombat.logText("Attack of Opportunity by: " + crt.Name, Color.Blue);
                         frm.currentCombat.logText(Environment.NewLine, Color.Black);
@@ -2442,7 +2480,17 @@ namespace IceBlink
                         c.logText(attackRoll.ToString() + " + " + attackMod.ToString() + " >= " + defense.ToString(), Color.Black);
                         c.logText(Environment.NewLine, Color.Black);
                         c.logText(Environment.NewLine, Color.Black);
-                                                
+
+                        #region onScoringHit script of creature
+                        IceBlinkCore.ScriptSelectEditorReturnObject scriptItem = crt.OnScoringHit;
+                        frm.doScriptBasedOnFilename(scriptItem.FilenameOrTag, scriptItem.Parm1, scriptItem.Parm2, scriptItem.Parm3, scriptItem.Parm4);
+                        #endregion
+
+                        #region onHit script of the player who got hit
+                        //IceBlinkCore.ScriptSelectEditorReturnObject scriptItem = pc.onHit;                
+                        frm.doScriptBasedOnFilename("pcOnHit.cs", "none", "none", "none", "none");
+                        #endregion
+
                         pc.HP = pc.HP - damage;
                         if (pc.HP <= 0)
                         {
@@ -2689,6 +2737,129 @@ namespace IceBlink
                 dist = deltaX;
             else
                 dist = deltaY;
+            return dist;
+        }
+        public int CalcDistance(PC disCr, PC disPC) //JamesManhattan 10/11/14 overloading this function so we can pass it creatures and pcs instead of always CombatLocation Points. Also allow for Large and Huge creatures
+        {
+            Point locCr = disCr.CombatLocation;
+            Point locPc = disPC.CombatLocation;
+
+            int dist = 0;
+            dist = CalcDistance(locCr, locPc);
+
+            return dist;
+        }
+        public int CalcDistance(Creature disCr, PC disPC) //JamesManhattan 10/11/14 overloading this function so we can pass it creatures and pcs instead of always CombatLocation Points. Also allow for Large and Huge creatures
+        {
+            Point locCr = disCr.CombatLocation;
+            Point locPc = disPC.CombatLocation;
+            Point locCr2 = disCr.CombatLocation;            
+            int dist = 0;
+            int dist2 = 0;
+            dist = CalcDistance(locCr, locPc);
+
+            if (disCr.Size > 1)
+            {
+                for (int x = 0; x <= disCr.Size-1; x++)
+                {
+                    for (int y = 0; y <= disCr.Size-1; y++)
+                    {
+                        locCr2.X = locCr.X + x;
+                        locCr2.Y = locCr.Y + y;
+                        dist2 = CalcDistance(locCr2, locPc);
+                        //frm.currentCombat.logText("crt to pc calcdistance x="+ x.ToString() + ",y=" + y.ToString() , Color.Blue);
+                        //frm.currentCombat.logText("crt to pc calcdistance dist=" + dist.ToString(), Color.Blue);
+                        if (dist2 < dist) { dist = dist2; }
+                    }
+                }
+            }
+          
+            return dist;
+        }
+        public int CalcDistance(Creature disCr, Point locPc) //JamesManhattan 10/11/14 overloading this function so we can pass it creatures and pcs instead of always CombatLocation Points. Also allow for Lrge and Huge creatures/
+        {
+            Point locCr = disCr.CombatLocation;
+            //Point locPc = disPC.CombatLocation;
+            Point locCr2 = disCr.CombatLocation;
+            int dist = 0;
+            int dist2 = 0;
+            dist = CalcDistance(locCr, locPc);
+
+            if (disCr.Size > 1 )
+            {
+                for (int x = 0; x <= disCr.Size - 1; x++)
+                {
+                    for (int y = 0; y <= disCr.Size - 1; y++)
+                    {
+                        locCr2.X = locCr.X + x;
+                        locCr2.Y = locCr.Y + y;
+                        dist2 = CalcDistance(locCr2, locPc);
+                        //frm.currentCombat.logText("crt to point calcdistance dist=" + dist.ToString(), Color.Blue);
+                        if (dist2 < dist) { dist = dist2; }
+                    }
+                }
+            }
+      
+            return dist;
+        }
+        public int CalcDistance(Creature disCr, Creature disPC) //JamesManhattan 10/11/14 overloading this function so we can pass it creatures and pcs instead of always CombatLocation Points. 
+        {
+            Point locCr = disCr.CombatLocation;
+            Point locPc = disPC.CombatLocation;
+            Point locCr2 = disCr.CombatLocation;
+            Point locPc2 = disCr.CombatLocation;
+            int dist = 0;
+            int dist2 = 0;
+            dist = CalcDistance(locCr, locPc);
+                     
+                for (int x = 0; x <= disCr.Size - 1; x++)
+                {
+                    for (int y = 0; y <= disCr.Size - 1; y++)
+                    {
+                       
+                            for (int a = 0; a <= disPC.Size - 1; a++)
+                            {
+                                for (int b = 0; b <= disPC.Size - 1; b++)
+                                {
+                                    locCr2.X = locCr.X + x;
+                                    locCr2.Y = locCr.Y + y;
+                                    locPc2.X = locPc.X + a;
+                                    locPc2.Y = locPc.Y + b;
+                                    dist2 = CalcDistance(locCr2, locPc2);
+                                    if (dist2 < dist) { dist = dist2; }
+                                }
+                            }                        
+                    }
+                }
+            
+        
+            return dist;
+        }
+        public int CalcDistance(PC disPC, Creature disCr) //JamesManhattan 10/11/14 overloading this function so we can pass it creatures and pcs instead of always CombatLocation Points. 
+        {
+            Point locCr = disCr.CombatLocation;
+            Point locPc = disPC.CombatLocation;
+            Point locCr2 = disCr.CombatLocation;
+            int dist = 0;
+            int dist2 = 0;
+            dist = CalcDistance(locCr, locPc);
+
+            if (disCr.Size > 1)
+            {
+                for (int x = 0; x <= disCr.Size - 1; x++)
+                {
+                    for (int y = 0; y <= disCr.Size - 1; y++)
+                    {
+                        locCr2.X = locCr.X + x;
+                        locCr2.Y = locCr.Y + y;
+                        dist2 = CalcDistance(locCr2, locPc);
+                        //frm.currentCombat.logText("Pc to crt calcdistance x=" + x.ToString() + ",y=" + y.ToString(), Color.Blue);
+                        //frm.currentCombat.logText("Pc to crt calcdistance dist=" + dist.ToString(), Color.Blue);
+                        if (dist2 < dist) { dist = dist2; }
+                    }
+                }
+            }
+
             return dist;
         }
         public Creature GetCreatureWithLowestHP()
@@ -3882,7 +4053,7 @@ namespace IceBlink
                             return variable.Value;
                         }
                     }
-                    	IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                    frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                     return null;
                 }
             }
@@ -3900,7 +4071,7 @@ namespace IceBlink
                         }
                     }
                     if (frm.debugMode)
-                    	IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                        frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                     return null;
                 }
                 #endregion
@@ -3917,7 +4088,7 @@ namespace IceBlink
                             }
                         }
                     	if (frm.debugMode)
-                    		IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return null;
                     }
                 }
@@ -3935,7 +4106,7 @@ namespace IceBlink
                             }
                         }
                    		if (frm.debugMode)
-                    		IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return null;
                     }
                 }
@@ -3956,7 +4127,7 @@ namespace IceBlink
                             }
                         }
                     	if (frm.debugMode)
-                    		IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return null;
                     }
                 }
@@ -3974,7 +4145,7 @@ namespace IceBlink
                             }
                         }
                     	if (frm.debugMode)
-                    		IBMessageBox.Show(gm, "Found the object, but couldn't find the tag specified...returning a value of -1");
+                            frm.logText("Found the object, but couldn't find the tag specified...returning a value of -1", Color.Yellow);
                         return null;
                     }
                 }
@@ -3982,7 +4153,7 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props), returning a value of -1");
+                frm.logText("couldn't find the object with the tag specified (only PCs, Creatures, Areas and Props), returning a value of -1", Color.Yellow);                
             }
             return null;
         }
@@ -4146,7 +4317,8 @@ namespace IceBlink
             }
             if (frm.debugMode) //SD_20131102
             {
-                IBMessageBox.Show(gm, "couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)");
+                frm.logText("couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)", Color.Yellow);
+                //IBMessageBox.Show(gm, "couldn't find the object with the tag (tag: " + objectTag + ") specified (only PCs, Creatures, Areas and Props)");
             }
         }        
 	//

--- a/scripts/crtOnStartCombatTurn.cs
+++ b/scripts/crtOnStartCombatTurn.cs
@@ -464,7 +464,7 @@ namespace IceBlink
                                     //if (c.IsVisibleLineOfSight(crt.CombatLocation, selectedPoint)) //make sure creature caster can actually see the target point. //this causes errors I think on points outside the map
                                     //{
                                     //c.logText("Selecting x=" + selectedPoint.X.ToString() + "y=" + selectedPoint.Y.ToString(), Color.Purple);
-                                    if (selectedPoint == crt.CombatLocation) {
+                                    if (sf.CalcDistance(crt.CombatLocation, selectedPoint) <= sf.SpellToCast.AoeRadiusOrLength) {
                                         utility = utility - 4; //the creature at least attempts to avoid hurting itself, but if surrounded might fireball itself!
                                         if (crt.HP <= crt.HPMax / 4) //caster is wounded, definately avoids itself.
                                         {
@@ -562,7 +562,7 @@ namespace IceBlink
                                         //if (c.IsVisibleLineOfSight(crt.CombatLocation, selectedPoint)) //make sure creature caster can actually see the target point. //this causes errors I think on points outside the map
                                         //{
                                             //c.logText("Selecting x=" + selectedPoint.X.ToString() + "y=" + selectedPoint.Y.ToString(), Color.Purple);
-                                            if (selectedPoint == crt.CombatLocation) {
+                                            if (sf.CalcDistance(crt.CombatLocation, selectedPoint) <= sf.SpellToCast.AoeRadiusOrLength) {
                                                 utility = utility - 4; //the creature at least attempts to avoid hurting itself, but if surrounded might fireball itself!
                                             } 
                                             foreach (Creature crtr in c.com_encounter.EncounterCreatureList.creatures) //if its allies are in the burst subtract a point, or half depending on how evil it is.

--- a/scripts/spSummonMonster
+++ b/scripts/spSummonMonster
@@ -15,7 +15,7 @@ namespace IceBlink
         public void Script(ScriptFunctions sf, string p1, string p2, string p3, string p4)
         {
             // C# code goes here
-            //This will summon a monster by Tag, it requires a custom script in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
+            //This will summon a monster by Tag, it requires a custom function in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
             if (sf.CombatSource is PC)
             {
                 PC source = (PC)sf.CombatSource;

--- a/scripts/spSummonMonster
+++ b/scripts/spSummonMonster
@@ -15,7 +15,7 @@ namespace IceBlink
         public void Script(ScriptFunctions sf, string p1, string p2, string p3, string p4)
         {
             // C# code goes here
-            //This will summon a monster by Tag, it requires a custom function in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
+            //This will summon a monster by Tag, it requires a custom function in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures(); A COPY OF THIS IS FAR BELOW IN COMMENTS
             if (sf.CombatSource is PC)
             {
                 PC source = (PC)sf.CombatSource;
@@ -114,4 +114,13 @@ namespace IceBlink
         }
         
     }
+    //THIS FUNCTION needs to be placed in Game.cs and compiled into a new program
+    //public void DisposePCOnlyCombatSpritesTextures()
+    //{ 
+	//foreach (SharpDX.Direct3D9.Sprite spr in pcCombatSprites)
+	//{
+	//	spr.Dispose();
+	//}
+	//pcCombatSprites.Clear();
+    //}
 }

--- a/scripts/spSummonMonster
+++ b/scripts/spSummonMonster
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+using System.Drawing;
+using IceBlinkCore;
+using IceBlink;
+using System.IO;
+
+namespace IceBlink
+{
+    public class IceBlinkScript
+    {
+        public void Script(ScriptFunctions sf, string p1, string p2, string p3, string p4)
+        {
+            // C# code goes here
+            //This will summon a monster by Tag, it requires a custom script in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
+            if (sf.CombatSource is PC)
+            {
+                PC source = (PC)sf.CombatSource;
+                //Creature target = (Creature)sf.CombatTarget;
+                Point target = (Point)sf.CombatTarget;
+                Combat c = sf.frm.currentCombat;
+
+                Creature summon = null;
+
+                summon = sf.gm.module.ModuleCreaturesList.getCreatureByTag("skele");
+                //c.logText(summon.Name + " has been picked" + Environment.NewLine, Color.YellowGreen);
+
+                // * add ResRefs to encounter and add creatures
+                int order = c.currentMoveOrderIndex;
+                Creature crt = new Creature();
+                CreatureRefs crt_ref = null;
+                int count = 1;
+
+                for (int i = 0; i < count; i++)
+                {
+                    // * ResRef
+                    crt_ref = new CreatureRefs();
+                    crt_ref.CreatureResRef = summon.ResRef;
+                    crt_ref.CreatureName = summon.Name + " Ally";
+                    crt_ref.CreatureTag = summon.Tag + "Ally" + i;
+                    ////crt_ref.CreatureStartLocation = new Point(frm.currentEncounter.EncounterPcStartLocations[0].X + gm.Random(6)-3,
+                    ////                             frm.currentEncounter.EncounterPcStartLocations[0].Y + 5 + gm.Random(3)-2);
+                    //crt_ref.CreatureStartLocation = new Point(0, i + 1);
+
+                    sf.gm.currentEncounter.EncounterCreatureRefsList.Add(crt_ref);
+
+                    // * creature
+                    crt = summon.DeepCopy();
+                    crt.Tag = summon.Tag + "Ally" + i;
+                    //crt.CombatLocation = new Point(0, i + 1);               
+                    //check if there is a creature already in the square chosen, then find nearest empty spot at random. this requires a custom checkPointCollision script in Combat.cs
+                    //int j = 0;
+                    //int k = 0;
+                    //do
+                    //{
+                    //    j = sf.gm.Random(-1, 1);
+                    //    k = sf.gm.Random(-1, 1);
+                    //    target.X = target.X + j;
+                    //    target.Y = target.Y + k;
+                    //} while (c.checkPointCollision(target)) ;                                        
+
+                    crt.CombatLocation = target; 
+
+                    crt.Tag = "Summoned " + summon.Name + " " + i; // * need to check for further summonings!
+                    crt.OnStartCombatTurn.FilenameOrTag = "crtPCAllyOnStartCombatTurn.cs"; //overwrite the AI to make it friendly to the players. not working right now
+                   
+                    //below line is necessary
+                    if (File.Exists(sf.gm.mainDirectory + "\\modules\\" + sf.gm.module.ModuleFolderName + "\\graphics\\sprites\\tokens\\module\\" + crt.SpriteFilename)) 
+                    {
+                        crt.LoadCharacterSprite(sf.gm.mainDirectory + "\\modules\\" + sf.gm.module.ModuleFolderName + "\\graphics\\sprites\\tokens\\module",  crt.SpriteFilename);
+                    }
+                    else if (File.Exists(sf.gm.mainDirectory + "\\data\\graphics\\sprites\\tokens\\" + crt.SpriteFilename)) 
+                    {
+                        crt.LoadCharacterSprite(sf.gm.mainDirectory + "\\data\\graphics\\sprites\\tokens", crt.SpriteFilename);
+                    }
+                    else
+                    {
+                        c.logText("Could not find sprite for " + crt.SpriteFilename + Environment.NewLine, Color.YellowGreen);
+                    }                   
+
+                    sf.gm.currentEncounter.EncounterCreatureList.creatures.Add(crt);
+                    //put it into the initiative tracker at the very end.
+                    MoveOrder mo = new MoveOrder();
+                    mo.index = sf.gm.currentEncounter.EncounterCreatureList.creatures.Count - 1;
+                    mo.type = "creature";
+                    mo.tag = crt.Tag;
+                    mo.rank = 0; // sf.gm.Random(20);// gm.Random(100) + (dexMod * 10) + Stats.CalcInitiativeBonuses(chr); 
+                    c.com_moveOrderList.Add(mo);
+
+                    c.logText(crt.Name + " has been summoned" + Environment.NewLine, Color.YellowGreen);
+                }
+
+                sf.gm.DisposePCOnlyCombatSpritesTextures(); //get rid of the PC textures because they are "ADDED" back in the grand Initialize function after this.
+                Thread.Sleep(200); //this allows all the floaty text to float away for its alloted time, which would cause rendering issues if not let to finish.
+                sf.gm.InitializeCombatRenderPanel(sf.gm.combatRenderPanel);  //WORKS!
+                
+            }
+            else if (sf.CombatSource is Creature)
+            {
+                Creature source = (Creature)sf.CombatSource;
+                ////PC target = (PC)sf.CombatTarget;
+                Point target = (Point)sf.CombatTarget;
+                Combat c = sf.frm.currentCombat;
+                
+            }
+            else // don't know who cast this spell
+            {
+                IBMessageBox.Show(sf.gm, "Invalid script owner, not a Creature or PC");
+                return;
+            }
+        }
+        
+    }
+}

--- a/scripts/spSummonMonster.cs
+++ b/scripts/spSummonMonster.cs
@@ -15,7 +15,8 @@ namespace IceBlink
         public void Script(ScriptFunctions sf, string p1, string p2, string p3, string p4)
         {
             // C# code goes here
-            //This will summon a monster by Tag, it requires a custom function in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures(); A COPY OF THIS IS FAR BELOW IN COMMENTS
+            //This will summon a Prop by Tag, it requires a custom script in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
+            //a copy of DisposePCOnlyCombatSpritesTextures is included in comments at very bottom of this file.
             if (sf.CombatSource is PC)
             {
                 PC source = (PC)sf.CombatSource;
@@ -51,21 +52,21 @@ namespace IceBlink
                     crt = summon.DeepCopy();
                     crt.Tag = summon.Tag + "Ally" + i;
                     //crt.CombatLocation = new Point(0, i + 1);               
-                    //check if there is a creature already in the square chosen, then find nearest empty spot at random. this requires a custom checkPointCollision script in Combat.cs
-                    //int j = 0;
-                    //int k = 0;
-                    //do
-                    //{
-                    //    j = sf.gm.Random(-1, 1);
-                    //    k = sf.gm.Random(-1, 1);
-                    //    target.X = target.X + j;
-                    //    target.Y = target.Y + k;
-                    //} while (c.checkPointCollision(target)) ;                                        
+                    //check if there is a creature already in the square chosen, then find nearest empty spot at random.
+                    int j = 0;
+                    int k = 0;
+                    do
+                    {
+                        j = sf.gm.Random(-1, 1);
+                        k = sf.gm.Random(-1, 1);
+                        target.X = target.X + j;
+                        target.Y = target.Y + k;
+                    } while (c.checkPointCollision(target)) ;                                        
 
                     crt.CombatLocation = target; 
 
                     crt.Tag = "Summoned " + summon.Name + " " + i; // * need to check for further summonings!
-                    crt.OnStartCombatTurn.FilenameOrTag = "crtPCAllyOnStartCombatTurn.cs"; //overwrite the AI to make it friendly to the players. not working right now
+                    crt.OnStartCombatTurn.FilenameOrTag = "crtPCAllyOnStartCombatTurn.cs"; //overwrite the AI to make it friendly to the players.
                    
                     //below line is necessary
                     if (File.Exists(sf.gm.mainDirectory + "\\modules\\" + sf.gm.module.ModuleFolderName + "\\graphics\\sprites\\tokens\\module\\" + crt.SpriteFilename)) 
@@ -114,13 +115,14 @@ namespace IceBlink
         }
         
     }
-    //THIS FUNCTION needs to be placed in Game.cs and compiled into a new program
+    //This function needs to be put into Game.cs and then a new IceBlinkCore.dll compiled from it.
     //public void DisposePCOnlyCombatSpritesTextures()
-    //{ 
-	//foreach (SharpDX.Direct3D9.Sprite spr in pcCombatSprites)
-	//{
-	//	spr.Dispose();
-	//}
-	//pcCombatSprites.Clear();
-    //}
+    //    {
+    //        foreach (SharpDX.Direct3D9.Sprite spr in pcCombatSprites)
+    //        {
+    //            spr.Dispose();
+    //        }    //        
+    //        //clear the floaty text pools because they cause issues.
+    //        shadowCombatTextPool.Clear();
+    //    }
 }

--- a/scripts/spSummonMonster.cs
+++ b/scripts/spSummonMonster.cs
@@ -17,6 +17,7 @@ namespace IceBlink
             // C# code goes here
             //This will summon a Prop by Tag, it requires a custom script in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
             //a copy of DisposePCOnlyCombatSpritesTextures is included in comments at very bottom of this file.
+            //it is required to be a "Point" target spell.
             if (sf.CombatSource is PC)
             {
                 PC source = (PC)sf.CombatSource;
@@ -53,15 +54,15 @@ namespace IceBlink
                     crt.Tag = summon.Tag + "Ally" + i;
                     //crt.CombatLocation = new Point(0, i + 1);               
                     //check if there is a creature already in the square chosen, then find nearest empty spot at random.
-                    int j = 0;
-                    int k = 0;
-                    do
-                    {
-                        j = sf.gm.Random(-1, 1);
-                        k = sf.gm.Random(-1, 1);
-                        target.X = target.X + j;
-                        target.Y = target.Y + k;
-                    } while (c.checkPointCollision(target)) ;                                        
+                    //int j = 0;
+                    //int k = 0;
+                    //do
+                    //{
+                    //    j = sf.gm.Random(-1, 1);
+                    //    k = sf.gm.Random(-1, 1);
+                    //    target.X = target.X + j;
+                    //    target.Y = target.Y + k;
+                    //} while (c.checkPointCollision(target)) ;    //this was a custom function to see if square is already occupied in Combat.cs                                    
 
                     crt.CombatLocation = target; 
 

--- a/scripts/spSummonProp.cs
+++ b/scripts/spSummonProp.cs
@@ -17,6 +17,7 @@ namespace IceBlink
             // C# code goes here
             //This will summon a Prop by Tag, it requires a custom script in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
             //a copy of DisposePCOnlyCombatSpritesTextures is included in comments at very bottom of this file.
+            //It is required to be a "Point" type target spell.
             if (sf.CombatSource is PC)
             {
                 PC source = (PC)sf.CombatSource;
@@ -53,15 +54,15 @@ namespace IceBlink
                     crt.Tag = summon.Tag + "Ally" + i;
                     //crt.CombatLocation = new Point(0, i + 1);               
                     //check if there is a creature already in the square chosen, then find nearest empty spot at random.
-                    int j = 0;
-                    int k = 0;
-                    do
-                    {
-                        j = sf.gm.Random(-1, 1);
-                        k = sf.gm.Random(-1, 1);
-                        target.X = target.X + j;
-                        target.Y = target.Y + k;
-                    } while (c.checkPointCollision(target)) ;                                        
+                    //int j = 0;
+                    //int k = 0;
+                    //do
+                    //{
+                    //    j = sf.gm.Random(-1, 1);
+                    //    k = sf.gm.Random(-1, 1);
+                    //    target.X = target.X + j;
+                    //    target.Y = target.Y + k;
+                    //} while (c.checkPointCollision(target)) ;  //this was a custom function to check for collisions of creatures or walls already in the square picked.                                      
 
                     crt.CombatLocation = target; 
 

--- a/scripts/spSummonProp.cs
+++ b/scripts/spSummonProp.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+using System.Drawing;
+using IceBlinkCore;
+using IceBlink;
+using System.IO;
+
+namespace IceBlink
+{
+    public class IceBlinkScript
+    {
+        public void Script(ScriptFunctions sf, string p1, string p2, string p3, string p4)
+        {
+            // C# code goes here
+            //This will summon a Prop by Tag, it requires a custom script in Game.cs called DisposePCOnlyCombatSpritesTextures(); which is just the foreach PC loop of DisposeCombatSpritesTextures();
+            //a copy of DisposePCOnlyCombatSpritesTextures is included in comments at very bottom of this file.
+            if (sf.CombatSource is PC)
+            {
+                PC source = (PC)sf.CombatSource;
+                //Creature target = (Creature)sf.CombatTarget;
+                Point target = (Point)sf.CombatTarget;
+                Combat c = sf.frm.currentCombat;
+
+                Creature summon = null;
+
+                summon = sf.gm.module.ModuleCreaturesList.getCreatureByTag("skele");
+                //c.logText(summon.Name + " has been picked" + Environment.NewLine, Color.YellowGreen);
+
+                // * add ResRefs to encounter and add creatures
+                int order = c.currentMoveOrderIndex;
+                Creature crt = new Creature();
+                CreatureRefs crt_ref = null;
+                int count = 1;
+
+                for (int i = 0; i < count; i++)
+                {
+                    // * ResRef
+                    crt_ref = new CreatureRefs();
+                    crt_ref.CreatureResRef = summon.ResRef;
+                    crt_ref.CreatureName = summon.Name + " Ally";
+                    crt_ref.CreatureTag = summon.Tag + "Ally" + i;
+                    ////crt_ref.CreatureStartLocation = new Point(frm.currentEncounter.EncounterPcStartLocations[0].X + gm.Random(6)-3,
+                    ////                             frm.currentEncounter.EncounterPcStartLocations[0].Y + 5 + gm.Random(3)-2);
+                    //crt_ref.CreatureStartLocation = new Point(0, i + 1);
+
+                    sf.gm.currentEncounter.EncounterCreatureRefsList.Add(crt_ref);
+
+                    // * creature
+                    crt = summon.DeepCopy();
+                    crt.Tag = summon.Tag + "Ally" + i;
+                    //crt.CombatLocation = new Point(0, i + 1);               
+                    //check if there is a creature already in the square chosen, then find nearest empty spot at random.
+                    int j = 0;
+                    int k = 0;
+                    do
+                    {
+                        j = sf.gm.Random(-1, 1);
+                        k = sf.gm.Random(-1, 1);
+                        target.X = target.X + j;
+                        target.Y = target.Y + k;
+                    } while (c.checkPointCollision(target)) ;                                        
+
+                    crt.CombatLocation = target; 
+
+                    crt.Tag = "Summoned " + summon.Name + " " + i; // * need to check for further summonings!
+                    crt.OnStartCombatTurn.FilenameOrTag = "crtPCAllyOnStartCombatTurn.cs"; //overwrite the AI to make it friendly to the players.
+                   
+                    //below line is necessary
+                    if (File.Exists(sf.gm.mainDirectory + "\\modules\\" + sf.gm.module.ModuleFolderName + "\\graphics\\sprites\\tokens\\module\\" + crt.SpriteFilename)) 
+                    {
+                        crt.LoadCharacterSprite(sf.gm.mainDirectory + "\\modules\\" + sf.gm.module.ModuleFolderName + "\\graphics\\sprites\\tokens\\module",  crt.SpriteFilename);
+                    }
+                    else if (File.Exists(sf.gm.mainDirectory + "\\data\\graphics\\sprites\\tokens\\" + crt.SpriteFilename)) 
+                    {
+                        crt.LoadCharacterSprite(sf.gm.mainDirectory + "\\data\\graphics\\sprites\\tokens", crt.SpriteFilename);
+                    }
+                    else
+                    {
+                        c.logText("Could not find sprite for " + crt.SpriteFilename + Environment.NewLine, Color.YellowGreen);
+                    }                   
+
+                    sf.gm.currentEncounter.EncounterCreatureList.creatures.Add(crt);
+                    //put it into the initiative tracker at the very end.
+                    MoveOrder mo = new MoveOrder();
+                    mo.index = sf.gm.currentEncounter.EncounterCreatureList.creatures.Count - 1;
+                    mo.type = "creature";
+                    mo.tag = crt.Tag;
+                    mo.rank = 0; // sf.gm.Random(20);// gm.Random(100) + (dexMod * 10) + Stats.CalcInitiativeBonuses(chr); 
+                    c.com_moveOrderList.Add(mo);
+
+                    c.logText(crt.Name + " has been summoned" + Environment.NewLine, Color.YellowGreen);
+                }
+
+                sf.gm.DisposePCOnlyCombatSpritesTextures(); //get rid of the PC textures because they are "ADDED" back in the grand Initialize function after this.
+                Thread.Sleep(200); //this allows all the floaty text to float away for its alloted time, which would cause rendering issues if not let to finish.
+                sf.gm.InitializeCombatRenderPanel(sf.gm.combatRenderPanel);  //WORKS!
+                
+            }
+            else if (sf.CombatSource is Creature)
+            {
+                Creature source = (Creature)sf.CombatSource;
+                ////PC target = (PC)sf.CombatTarget;
+                Point target = (Point)sf.CombatTarget;
+                Combat c = sf.frm.currentCombat;
+                
+            }
+            else // don't know who cast this spell
+            {
+                IBMessageBox.Show(sf.gm, "Invalid script owner, not a Creature or PC");
+                return;
+            }
+        }
+        
+    }
+    //This function needs to be put into Game.cs and then a new IceBlinkCore.dll compiled from it.
+    //public void DisposePCOnlyCombatSpritesTextures()
+    //    {
+    //        foreach (SharpDX.Direct3D9.Sprite spr in pcCombatSprites)
+    //        {
+    //            spr.Dispose();
+    //        }    //        
+    //        //clear the floaty text pools because they cause issues.
+    //        shadowCombatTextPool.Clear();
+    //    }
+}


### PR DESCRIPTION
Overloaded the CalcDistance function so it can take Creatures and PCs as inputs instead of just CombatLocations. This way the function can handle Large and Huge creatures and still calculate the right distances to the nearest edges of creatures. 

So scripts in dsPCAttack and dsCreatureAttack scripts need to be updated when they check for opportunity attacks etc.

Also changed the error message for the functions GetLocalInt and GetGlobalInt so that they simply output log messages instead of creating popups when they can't find an Int. Those popups were annoying.
